### PR TITLE
Added min_confidence. Fixed bounding box issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ $ python3 coral-app.py --models-directory models
 ```
 Then use curl to query:
 ```
-curl -X POST -F image=@images/test-image3.jpg 'http://localhost:5000/v1/vision/detection'
+curl -X POST -F image=@images/test-image3.jpg -F min_confidence=.5 'http://localhost:5000/v1/vision/detection'
 
 {'predictions': [{'confidence': 0.953125,
    'label': 'person',


### PR DESCRIPTION
This should fix #58 - It'll allow you to set a min_confidence in the form post similar to how deepstack operates.
I also noticed that my bounding boxes were all out of whack, similar to #62 . I think @robmarkcole was right on the money with the resize to 300x300.

Following this example: https://github.com/google-coral/pycoral/blob/master/examples/detect_image.py

I reworked it so that it didn't resize the image prior to calling interpreter.invoke().
I also borrowed some code to write out how much processing time each run takes, but I commented it out so as not to spam 
the log.

I also noticed that you could reference bbox.ymin in the pycoral docs, so I swapped out the bbox[0] so that its a little more clear.

Lastly, I switched out the print for the global interpreter to use a logging.debug instead. This'll print it out to the docker container.

BTW - once a new release is made in this repo, I can update https://github.com/sstratoti/docker-coral-rest-server Dockerfile which I forked from another user and have since updated with some fixes. This is working pretty great so far!